### PR TITLE
Added 'no encryption' warning to JavaJobSerializer

### DIFF
--- a/src/main/java/org/whispersystems/jobqueue/persistence/JavaJobSerializer.java
+++ b/src/main/java/org/whispersystems/jobqueue/persistence/JavaJobSerializer.java
@@ -31,6 +31,10 @@ import java.io.StringWriter;
 /**
  * An implementation of {@link org.whispersystems.jobqueue.persistence.JobSerializer} that uses
  * Java Serialization.
+ *
+ * <b>NOTE</b>: This class does not encrypt/decrypt jobs even if the {@code Job} has {@code EncryptionKeys}.
+ * This means that the {@code keys} and {@code encrypted} parameters are ignored by this implementation of
+ * {@link org.whispersystems.jobqueue.persistence.JobSerializer}.
  */
 public class JavaJobSerializer implements JobSerializer {
 


### PR DESCRIPTION
Given that JavaJobSerializer does not encrypt/decrypt jobs even if they
actually do have EncryptionKeys it is useful for those who use this
class to know that their Jobs will not be encrypted.
